### PR TITLE
Use shortjournal instead of journaltitle for biblatex

### DIFF
--- a/LaTeX/A4/jacow.cls
+++ b/LaTeX/A4/jacow.cls
@@ -573,6 +573,7 @@
 %       https://tex.stackexchange.com/questions/10203/biblatex-putting-thin-spaces-between-initials
 %       https://tex.stackexchange.com/questions/560346/how-to-suppress-annotation-field-from-bbl-file-in-biblatex
 %       https://tex.stackexchange.com/questions/496995/advanced-introduction-to-biblatex-coding-guidelines-for-database
+%       https://tex.stackexchange.com/questions/31616/how-to-use-shortjournal-with-biblatex-and-biblatex-chem																			
 %-------------------------------------
 %
 % if BibLaTeX is used
@@ -655,6 +656,24 @@
  	        \usebibmacro{url+urldate}}%
  	        {}%
  	}
+	%
+  % Use shortjournal if available, otherwise journaltitle
+  %
+  \renewbibmacro*{journal}{%
+    \iffieldundef{shortjournal}{%
+      \iffieldundef{journaltitle}
+        {}
+        {%
+          \printtext[journaltitle]
+            {%
+              \printfield[titlecase]{journaltitle}%
+              \setunit{\subtitlepunct}%
+              \printfield[titlecase]{journalsubtitle}%
+            }%
+        }%
+    }
+    {\printtext[journaltitle]{\printfield[titlecase]{shortjournal}}}%
+  }
  	% format ISSN like URLs
   	\DeclareFieldFormat{issn}{%
   	    {\texttt{ISSN:#1}}%


### PR DESCRIPTION
Dear JACoW-Team,

after submission of my proceeding draft for IPAC2023 I got the feedback that I should use the journal abbrevations instead of the full journal name. Since the abbrevations were already in the submitted .bib-file it is more beneficial to configure biblatex to use it instead of the journaltitle field. I added to code of the current commit to my .tex-file but is of course advantegeous for everyone who uses biblatex.
So I've added it to jacow.cls and tested it with my manuscript.

Are pull requests via github welcome?