### PR TITLE
Fix `@software` ends with a comma

### DIFF
--- a/LaTeX/jacow.bbx
+++ b/LaTeX/jacow.bbx
@@ -518,7 +518,7 @@
       \printlist{organization}
       \newunit\newblock
       \printdate
-      \newunit\newblock
+      \setunit{\addperiod\addspace}\newblock
       \printfirst{doi,url} %»
     \usebibmacro{finentry}
   } %»
@@ -927,5 +927,3 @@
   }
 
 \endinput
-
-jacow.bbx: JACoW’s biblatex bibliography style


### PR DESCRIPTION
`@software`-type of references ended with a comma rather than a period when `url`/`doi` is available, which not consistent with the JACoW style.